### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: hersh-CI
+on: [push, pull_request]
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: configure
+        run: cmake -S . -B build
+      - name: build
+        run: cmake --build build -j2
+      - name: test
+        run: ctest --test-dir build
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,5 @@ jobs:
       - name: build
         run: cmake --build build -j2
       - name: test
-        run: ctest --test-dir build
+        run: ctest --test-dir build --output-on-failure
 


### PR DESCRIPTION
Add CI functionality via github actions.
Perform 3 steps:
1) Configure project with CMAKE.
2) Build project with CMAKE.
3) Run tests with ctest.